### PR TITLE
Add LF version and use https for DSE downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN set -x \
     && export DSE_TEMP="$(mktemp -d)" \
     && cd "$DSE_TEMP" \
     && curl -SLO "$DSE_CREDENTIALS_URL/.netrc" \
-    && curl --netrc-file .netrc -SLO "http://downloads.datastax.com/enterprise/dse-$DSE_VERSION-bin.tar.gz" \
-    && curl --netrc-file .netrc -SLO "http://downloads.datastax.com/enterprise/dse-$DSE_VERSION-bin.tar.gz.md5" \
+    && curl --netrc-file .netrc -SLO "https://downloads.datastax.com/enterprise/dse-$DSE_VERSION-bin.tar.gz" \
+    && curl --netrc-file .netrc -SLO "https://downloads.datastax.com/enterprise/dse-$DSE_VERSION-bin.tar.gz.md5" \
     && md5sum -c *.md5 \
     && tar -xzf "dse-$DSE_VERSION-bin.tar.gz" -C /opt \
     && cd / \

--- a/build/LF_VERSION
+++ b/build/LF_VERSION
@@ -1,0 +1,1 @@
+LF_VERSION=1

--- a/build/docker-build.sh
+++ b/build/docker-build.sh
@@ -8,11 +8,14 @@ if [[ -z "$DSE_CREDENTIALS_URL" ]]; then
   exit 1
 fi
 
-# Set the DSE_VERSION so it can be used then run docker build
+# Set the DSE_VERSION so it can be used by docker build
 . "`dirname $0`/DSE_VERSION"
 
+# Set the LF_VERSION so it can be used by docker build
+. "`dirname $0`/LF_VERSION"
+
 # Run the build
-docker build --build-arg DSE_VERSION=$DSE_VERSION --build-arg DSE_CREDENTIALS_URL=$DSE_CREDENTIALS_URL -t leadfeeder/dse-docker:$DSE_VERSION-1 .
+docker build --build-arg DSE_VERSION=$DSE_VERSION --build-arg DSE_CREDENTIALS_URL=$DSE_CREDENTIALS_URL -t leadfeeder/dse-docker:$DSE_VERSION-$LF_VERSION .
 
 # Output some image information after the build is finished
 docker images leadfeeder/dse-docker


### PR DESCRIPTION
After merging, a tag of `5.0.12-1` should be added for this commit.

Partially implements https://github.com/Leadfeeder/issue-tracker/issues/6147